### PR TITLE
Fix typo in README and  IBlueprintManager.

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ The repo also contains several blueprints:
 - `ERC20Blueprint` – wraps ERC20 tokens into a token in the system; has ERC777 support
 - `VestingBlueprint` – creates vesting positions according to a custom vesting schedule
 	- `LinearCliffVestingSchedule` – a linear vesting schedule with a cliff
-- `BasketBlueprint` – allows for creation of baskets of tokens expressable by a single token
+- `BasketBlueprint` – allows for creation of baskets of tokens expressible by a single token
 
 ## Safety
 

--- a/src/interfaces/IBlueprintManager.sol
+++ b/src/interfaces/IBlueprintManager.sol
@@ -30,7 +30,7 @@ interface IBlueprintManager {
 	///       via cook invoked by the user or their operator
 	function mint(address to, uint256 tokenId, uint256 amount) external;
 
-	/// @notice mints many tupes of tokens according to the `ops` array
+	/// @notice mints many types of tokens according to the `ops` array
 	/// @param to the address to mint to
 	/// @param ops the array of Blueprint's token ids and amounts to mint
 	/// @dev keep in mind that burning (inverting this action) is only possible


### PR DESCRIPTION
This PR fixes a small typo in the README and IBlueprintManager. No functionality is affected just a minor documentation update.

Changes:
Fixed "expressable" spelling -- "expressible"
Fixed "tupes" spelling -- "types"

Let me know if there are any other documentation improvements you'd like included. Thanks!

