### PR TITLE
Add permit-like functionality to the manager, both for approvals and operators.

### DIFF
--- a/src/BlueprintManager.sol
+++ b/src/BlueprintManager.sol
@@ -13,88 +13,179 @@ import {
 } from "./FlashAccounting.sol";
 
 contract BlueprintManager is IBlueprintManager, FlashAccounting {
-	error InvalidChecksum();
-	error AccessDenied();
-	error RealizeAccessDenied();
+    error InvalidChecksum();
+    error AccessDenied();
+    error RealizeAccessDenied();
+    error InvalidSignature();
 
-	/// @notice eip-6909 operator mapping
-	mapping(address => mapping(address => bool)) public isOperator;
-	/// @notice eip-6909 balance mapping
-	mapping(address => mapping(uint256 => uint256)) public balanceOf;
-	/// @notice eip-6909 allowance mapping
-	mapping(address => mapping(address => mapping(uint256 => uint256))) public allowance;
+    /// @notice eip-6909 operator mapping
+    mapping(address => mapping(address => bool)) public isOperator;
+    /// @notice eip-6909 balance mapping
+    mapping(address => mapping(uint256 => uint256)) public balanceOf;
+    /// @notice eip-6909 allowance mapping
+    mapping(address => mapping(address => mapping(uint256 => uint256))) public allowance;
 
-	function _mint(address to, uint256 id, uint256 amount) internal override {
-		balanceOf[to][id] += amount;
-	}
+    /// @notice Domain separator for EIP-712 signatures
+    bytes32 public DOMAIN_SEPARATOR;
 
-	function _burn(address from, uint256 id, uint256 amount) internal override {
-		balanceOf[from][id] -= amount;
-	}
+    // Struct and type hashes for EIP-712 permit function
+    bytes32 public constant APPROVAL_TYPEHASH = keccak256(
+        "Permit(address owner,address spender,uint256 id,uint256 amount,uint256 nonce,uint256 deadline)"
+    );
+    bytes32 public constant OPERATOR_TYPEHASH = keccak256(
+        "PermitOperator(address owner,address operator,bool approved,uint256 nonce,uint256 deadline)"
+    );
 
-	function _transferFrom(
-		address from,
-		address to,
-		uint256 id,
-		uint256 amount
-	) internal {
-		_burn(from, id, amount);
-		_mint(to, id, amount);
-	}
+    mapping(address => uint256) public nonces;
 
-	function _decreaseApproval(address sender, uint256 id, uint256 amount) internal {
-		uint256 allowed = allowance[sender][msg.sender][id];
-		if (allowed != type(uint256).max)
-			allowance[sender][msg.sender][id] = allowed - amount;
-	}
+    constructor() {
+        uint256 chainId;
+        assembly {
+            chainId := chainid()
+        }
+        DOMAIN_SEPARATOR = keccak256(
+            abi.encode(
+                keccak256(
+                    "EIP712Domain(string name,string version,uint256 chainId,address verifyingContract)"
+                ),
+                keccak256(bytes("BlueprintManager")),
+                keccak256(bytes("1")),
+                chainId,
+                address(this)
+            )
+        );
+    }
 
-	/**
-	 * @notice transfers `amount` of token `id` to `receiver`
-	 * @dev reverts on failure
-	 * @return is always true if didn't revert
-	 */
-	function transfer(
-		address receiver,
-		uint256 id,
-		uint256 amount
-	) public virtual returns (bool) {
-		_transferFrom(msg.sender, receiver, id, amount);
+    function _mint(address to, uint256 id, uint256 amount) internal override {
+        balanceOf[to][id] += amount;
+    }
 
-		return true;
-	}
+    function _burn(address from, uint256 id, uint256 amount) internal override {
+        balanceOf[from][id] -= amount;
+    }
 
-	function transferFrom(
-		address sender,
-		address receiver,
-		uint256 id,
-		uint256 amount
-	) public virtual returns (bool) {
-		if (msg.sender != sender && !isOperator[sender][msg.sender])
-			_decreaseApproval(sender, id, amount);
+    function _transferFrom(
+        address from,
+        address to,
+        uint256 id,
+        uint256 amount
+    ) internal {
+        _burn(from, id, amount);
+        _mint(to, id, amount);
+    }
 
-		_transferFrom(sender, receiver, id, amount);
+    function _decreaseApproval(address sender, uint256 id, uint256 amount) internal {
+        uint256 allowed = allowance[sender][msg.sender][id];
+        if (allowed != type(uint256).max)
+            allowance[sender][msg.sender][id] = allowed - amount;
+    }
 
-		return true;
-	}
+    function transfer(
+        address receiver,
+        uint256 id,
+        uint256 amount
+    ) public virtual returns (bool) {
+        _transferFrom(msg.sender, receiver, id, amount);
+        return true;
+    }
 
-	function approve(
-		address spender,
-		uint256 id,
-		uint256 amount
-	) public virtual returns (bool) {
-		allowance[msg.sender][spender][id] = amount;
+    function transferFrom(
+        address sender,
+        address receiver,
+        uint256 id,
+        uint256 amount
+    ) public virtual returns (bool) {
+        if (msg.sender != sender && !isOperator[sender][msg.sender])
+            _decreaseApproval(sender, id, amount);
 
-		return true;
-	}
+        _transferFrom(sender, receiver, id, amount);
+        return true;
+    }
 
-	function setOperator(
-		address operator,
-		bool approved
-	) public virtual returns (bool) {
-		isOperator[msg.sender][operator] = approved;
+    function approve(
+        address spender,
+        uint256 id,
+        uint256 amount
+    ) public virtual returns (bool) {
+        allowance[msg.sender][spender][id] = amount;
+        return true;
+    }
 
-		return true;
-	}
+    function setOperator(
+        address operator,
+        bool approved
+    ) public virtual returns (bool) {
+        isOperator[msg.sender][operator] = approved;
+        return true;
+    }
+
+    // EIP-712 permit function for approvals
+    function permit(
+        address owner,
+        address spender,
+        uint256 id,
+        uint256 amount,
+        uint256 deadline,
+        uint8 v,
+        bytes32 r,
+        bytes32 s
+    ) external {
+        require(block.timestamp <= deadline, "Permit: expired deadline");
+
+        bytes32 structHash = keccak256(
+            abi.encode(
+                APPROVAL_TYPEHASH,
+                owner,
+                spender,
+                id,
+                amount,
+                nonces[owner]++,
+                deadline
+            )
+        );
+
+        bytes32 hash = keccak256(
+            abi.encodePacked("\x19\x01", DOMAIN_SEPARATOR, structHash)
+        );
+
+        address signer = ecrecover(hash, v, r, s);
+        require(signer != address(0) && signer == owner, "InvalidSignature");
+
+        allowance[owner][spender][id] = amount;
+    }
+
+    // EIP-712 permit function for operator approvals
+    function permitOperator(
+        address owner,
+        address operator,
+        bool approved,
+        uint256 deadline,
+        uint8 v,
+        bytes32 r,
+        bytes32 s
+    ) external {
+        require(block.timestamp <= deadline, "Permit: expired deadline");
+
+        bytes32 structHash = keccak256(
+            abi.encode(
+                OPERATOR_TYPEHASH,
+                owner,
+                operator,
+                approved,
+                nonces[owner]++,
+                deadline
+            )
+        );
+
+        bytes32 hash = keccak256(
+            abi.encodePacked("\x19\x01", DOMAIN_SEPARATOR, structHash)
+        );
+
+        address signer = ecrecover(hash, v, r, s);
+        require(signer != address(0) && signer == owner, "InvalidSignature");
+
+        isOperator[owner][operator] = approved;
+    }
 
 	function cook(
 		address realizer,


### PR DESCRIPTION
**Domain Separator and Type Hashes**: Defined constants for EIP-712 permit functionality.
**Nonces**: Added nonces to ensure each signature is unique.
**`permit` Function**: Allows a user to approve a spender for a token via signature.
**`permitOperator` Function**: Allows a user to set an operator via signature.
**Signature Verification**: `ecrecover` is used to verify the user’s signature, providing security and preventing unauthorized transactions.